### PR TITLE
Add version independent asyncio compat

### DIFF
--- a/girc/asyncio_compat.py
+++ b/girc/asyncio_compat.py
@@ -1,0 +1,23 @@
+"""
+Version independent compat wrapper for asyncio
+"""
+
+import asyncio
+
+__all__ = ('ensure_future',)
+
+
+def ensure_future(fut, *, loop=None):
+    """
+    Wraps asyncio.async()/asyncio.ensure_future() depending on the python version
+    :param fut: The awaitable, future, or coroutine to wrap
+    :param loop: The loop to run in
+    :return: The wrapped future
+    """
+    if sys.version_info < (3, 4, 4):
+        # This is to avoid a SyntaxError on 3.7.0a2+
+        func = getattr(asyncio, "async")
+    else:
+        func = asyncio.ensure_future
+
+    return func(fut, loop=loop)  # pylint: disable=locally-disabled, deprecated-method

--- a/girc/client.py
+++ b/girc/client.py
@@ -5,6 +5,7 @@ import asyncio
 import base64
 import re
 
+from . import asyncio_compat
 from .ircreactor.events import EventManager
 from .ircreactor.envelope import RFC1459Message
 
@@ -497,10 +498,8 @@ class ServerConnection(asyncio.Protocol):
                 def channel_joiner(seconds_to_wait, channels):
                     yield from asyncio.sleep(seconds_to_wait)
                     self.join_channels(*channels)
-                try:
-                    asyncio.ensure_future(channel_joiner(seconds, channels))
-                except AttributeError:
-                    asyncio.async(channel_joiner(seconds, channels))
+
+                asyncio_compat.ensure_future(channel_joiner(seconds, channels))
             else:
                 self.join_channels(*channels)
 


### PR DESCRIPTION
Wrap asyncio.ensure_future()/asycnio.async() and use whichever is
available, avoiding SyntaxError on newer python versions